### PR TITLE
Fix indentation for usernames in ftp.yaml

### DIFF
--- a/nettacker/modules/brute/ftp.yaml
+++ b/nettacker/modules/brute/ftp.yaml
@@ -17,7 +17,7 @@ payloads:
         ports:
           - 21
         usernames:
-          - root
+        - root
           - admin
           - user
           - test


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix indentation of the `usernames` list in `nettacker/modules/brute/ftp.yaml` so the YAML parses correctly. This ensures all default FTP usernames are loaded and used during brute-force scans.

<sup>Written for commit add10d1b4deb9461f164c44ae4041215ec6e9b4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

